### PR TITLE
Add schema for menu_items table and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
+# Restaurant Application
 
+Before running the server make sure the database has the required tables.
+
+Create the `menu_items` table using the SQL script under `backend/docs/schema.sql`:
+
+```sh
+sqlite3 path/to/your.db < backend/docs/schema.sql
+```
+
+Adjust the database path as needed.

--- a/backend/docs/schema.sql
+++ b/backend/docs/schema.sql
@@ -1,0 +1,9 @@
+-- Schema for menu_items table
+-- This table is used by src/routes/menu.ts
+
+CREATE TABLE IF NOT EXISTS menu_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    description TEXT,
+    price REAL NOT NULL
+);


### PR DESCRIPTION
## Summary
- add SQL schema for `menu_items` table in `backend/docs/schema.sql`
- update README with instructions to run the schema script before starting the server

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a261d8688325b69b6be319f18e91